### PR TITLE
Add Example management feature with endpoints and adapters

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.2.1" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.2.1" />
     <PackageVersion Include="Aspire.Npgsql" Version="9.2.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.2.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
@@ -15,5 +16,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.2.2" />
   </ItemGroup>
 </Project>

--- a/src/ALB.Api/ALB.Api.csproj
+++ b/src/ALB.Api/ALB.Api.csproj
@@ -9,11 +9,13 @@
     <ItemGroup>
         <PackageReference Include="Aspire.Npgsql" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+        <PackageReference Include="Scalar.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\aspire\ALB.ServiceDefaults\ALB.ServiceDefaults.csproj" />
       <ProjectReference Include="..\ALB.Domain\ALB.Domain.csproj" />
+      <ProjectReference Include="..\ALB.Infrastructure\ALB.Infrastructure.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/ALB.Api/Program.cs
+++ b/src/ALB.Api/Program.cs
@@ -1,17 +1,36 @@
+using ALB.Api.UseCases.ExampleFeatures.Endpoints;
+using ALB.Infrastructure.Extensions;
+using Microsoft.AspNetCore.HttpOverrides;
+using Scalar.AspNetCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.AddServiceDefaults();
+
+// This is needed to make OpenApi forwarding possible behind aspires reverse proxy.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders =
+        ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+});
+
+builder.Services.AddInfrastructure();
+
 builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+app.UseExceptionHandler("/Error");
+app.UseForwardedHeaders();
+app.MapOpenApi();
+app.MapScalarApiReference("/api-reference", options => 
 {
-    app.MapOpenApi();
-}
+    options.WithTitle("Saga Demo API")
+        .WithTheme(ScalarTheme.Moon)
+        .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient);
+});
 
-app.UseHttpsRedirection();
+app.MapExampleEndpoints();
 
 app.Run();

--- a/src/ALB.Api/Properties/launchSettings.json
+++ b/src/ALB.Api/Properties/launchSettings.json
@@ -5,16 +5,8 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
+      "launchUrl": "api-reference",
       "applicationUrl": "http://localhost:5206",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "https://localhost:7199;http://localhost:5206",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ALB.Api/UseCases/ExampleFeatures/Endpoints/Create/CreateExampleEndpoints.cs
+++ b/src/ALB.Api/UseCases/ExampleFeatures/Endpoints/Create/CreateExampleEndpoints.cs
@@ -1,0 +1,21 @@
+using ALB.Infrastructure.Persistence.Examples.Adapters;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ALB.Api.UseCases.ExampleFeatures.Endpoints.Create;
+
+internal static class CreateExampleEndpoints
+{
+    internal static void MapCreateExampleEndpoint(this RouteGroupBuilder app)
+    {
+        app.MapPost("/", async Task<Results<Ok<ExampleCreatedResponse>, BadRequest>> (CreateExampleRequest request, IExamplesAdapter adapter) =>
+            {
+                var result = await adapter.CreateExampleAsync(request.Name);
+                return TypedResults.Ok(new ExampleCreatedResponse(result.Id, result.Name));
+            }) //.RequireAuthorization(SystemRoles.AdminPolicy)
+            .WithOpenApi();
+    }
+}
+
+public record CreateExampleRequest(string Name);
+public record ExampleCreatedResponse(Guid Id, string Name);

--- a/src/ALB.Api/UseCases/ExampleFeatures/Endpoints/Delete/DeleteExampleEndpoints.cs
+++ b/src/ALB.Api/UseCases/ExampleFeatures/Endpoints/Delete/DeleteExampleEndpoints.cs
@@ -1,0 +1,16 @@
+using ALB.Infrastructure.Persistence.Examples.Adapters;
+
+namespace ALB.Api.UseCases.ExampleFeatures.Endpoints.Delete;
+
+internal static class DeleteExampleEndpoints
+{
+    internal static void MapDeleteExampleEndpoint(this RouteGroupBuilder app)
+    {
+        app.MapDelete("/{id:guid}", async (Guid id, IExamplesAdapter adapter) =>
+            {
+                await adapter.DeleteExampleAsync(id);
+                return Results.NoContent();
+            }) //.RequireAuthorization(SystemRoles.AdminPolicy)
+           .WithOpenApi();
+    }
+}

--- a/src/ALB.Api/UseCases/ExampleFeatures/Endpoints/ExampleEndpoints.cs
+++ b/src/ALB.Api/UseCases/ExampleFeatures/Endpoints/ExampleEndpoints.cs
@@ -1,0 +1,15 @@
+using ALB.Api.UseCases.ExampleFeatures.Endpoints.Create;
+using ALB.Api.UseCases.ExampleFeatures.Endpoints.Delete;
+
+namespace ALB.Api.UseCases.ExampleFeatures.Endpoints;
+
+internal static class ExampleEndpoints
+{
+    internal static void MapExampleEndpoints(this IEndpointRouteBuilder groupBuilder)
+    {
+        var examplesGroup = groupBuilder.MapGroup("examples");
+
+        examplesGroup.MapCreateExampleEndpoint();
+        examplesGroup.MapDeleteExampleEndpoint();
+    }
+}

--- a/src/ALB.Domain/Entities/Example.cs
+++ b/src/ALB.Domain/Entities/Example.cs
@@ -1,0 +1,7 @@
+namespace ALB.Domain.Entities;
+
+public class Example
+{
+    public Guid Id { get; init; }
+    public required string Name { get; init; }
+}

--- a/src/ALB.Infrastructure/ALB.Infrastructure.csproj
+++ b/src/ALB.Infrastructure/ALB.Infrastructure.csproj
@@ -7,8 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\ALB.Api\ALB.Api.csproj" />
       <ProjectReference Include="..\ALB.Domain\ALB.Domain.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     </ItemGroup>
 
 </Project>

--- a/src/ALB.Infrastructure/Extensions/InfrastructureExtension.cs
+++ b/src/ALB.Infrastructure/Extensions/InfrastructureExtension.cs
@@ -1,0 +1,16 @@
+using ALB.Infrastructure.Persistence.Examples;
+using ALB.Infrastructure.Persistence.Examples.Adapters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ALB.Infrastructure.Extensions;
+
+public static class InfrastructureExtension
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+    {
+        // Caution, DbContexts arent added this way!
+        services.AddSingleton<ExamplesDbContext>();
+        services.AddScoped<IExamplesAdapter, ExamplesAdapter>();
+        return services;
+    }
+}

--- a/src/ALB.Infrastructure/Persistence/Examples/Adapters/ExamplesAdapter.cs
+++ b/src/ALB.Infrastructure/Persistence/Examples/Adapters/ExamplesAdapter.cs
@@ -1,0 +1,18 @@
+using ALB.Domain.Entities;
+
+namespace ALB.Infrastructure.Persistence.Examples.Adapters;
+
+public class ExamplesAdapter(ExamplesDbContext context): IExamplesAdapter
+{
+    public Task<Example> CreateExampleAsync(string name)
+    {
+        // Here you would use the DbContext
+        throw new NotImplementedException();
+    }
+
+    public Task DeleteExampleAsync(Guid id)
+    {
+        // Here you would use the DbContext
+        throw new NotImplementedException();
+    }
+}

--- a/src/ALB.Infrastructure/Persistence/Examples/Adapters/IExamplesAdapter.cs
+++ b/src/ALB.Infrastructure/Persistence/Examples/Adapters/IExamplesAdapter.cs
@@ -1,0 +1,9 @@
+using ALB.Domain.Entities;
+
+namespace ALB.Infrastructure.Persistence.Examples.Adapters;
+
+public interface IExamplesAdapter
+{
+    public Task<Example> CreateExampleAsync(string name);
+    public Task DeleteExampleAsync(Guid id);
+}

--- a/src/ALB.Infrastructure/Persistence/Examples/ExamplesDbContext.cs
+++ b/src/ALB.Infrastructure/Persistence/Examples/ExamplesDbContext.cs
@@ -1,0 +1,6 @@
+namespace ALB.Infrastructure.Persistence.Examples;
+
+public class ExamplesDbContext
+{
+    
+}


### PR DESCRIPTION
Introduced `Example` entity, DbContext, and adapter for persistence. Added Create and Delete Example endpoints to the API, integrated with `IExamplesAdapter`. Updated services and dependencies, including OpenAPI and Scalar API support.