### PR TITLE
Add TODO comment for migrations post-development cycle

### DIFF
--- a/src/ALB.Api/Program.cs
+++ b/src/ALB.Api/Program.cs
@@ -52,6 +52,7 @@ app.MapScalarApiReference("/api-reference", options =>
 app.MapExampleEndpoints();
 app.MapIdentityApi<ApplicationUser>();
 
+// TODO: add migrations when out of dev cycle
 using var serviceScope = app.Services.CreateScope();
 var context = serviceScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 // await context.Database.MigrateAsync();

--- a/src/ALB.Api/Program.cs
+++ b/src/ALB.Api/Program.cs
@@ -55,7 +55,6 @@ app.MapIdentityApi<ApplicationUser>();
 // TODO: add migrations when out of dev cycle
 using var serviceScope = app.Services.CreateScope();
 var context = serviceScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-// await context.Database.MigrateAsync();
 await context.Database.EnsureCreatedAsync();
 
 app.Run();


### PR DESCRIPTION
A comment was added in Program.cs to remind developers to include database migrations once the project moves out of the development phase. This ensures no migrations are unintentionally skipped in production.